### PR TITLE
Ability to generate multiple independently incremented build numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Generate build number
-      uses: einaregilsson/build-number@v1 
+      uses: einaregilsson/build-number@v2 
       with:
         token: ${{secrets.github_token}}        
     - name: Print new build number
@@ -24,7 +24,7 @@ jobs:
     steps:
     - name: Generate build number
       id: buildnumber
-      uses: einaregilsson/build-number@v1 
+      uses: einaregilsson/build-number@v2 
       with:
         token: ${{secrets.github_token}}        
     
@@ -47,7 +47,7 @@ jobs:
     steps:
     - name: Generate build number
       id: buildnumber
-      uses: einaregilsson/build-number@v1 
+      uses: einaregilsson/build-number@v2 
       with:
         token: ${{secrets.github_token}}        
     - name: Upload build number
@@ -65,12 +65,23 @@ jobs:
         name: BUILD_NUMBER
     - name: Restore build number
       id: buildnumber
-      uses: einaregilsson/build-number@v1 
+      uses: einaregilsson/build-number@v2 
     
     # Don't need to add Github token here, since you're only getting an artifact.
     # After this runs you'll again have the $BUILD_NUMBER environment variable, and 
     # the ${{ steps.buildnumber.outputs.build_number }} output.
 ```
+
+## Setting the initial build number.
+
+If you're moving from another build system, you might want to start from some specific number. The `build-number` action simply uses a special tag name to store the build number, `build-number-x`, so you can just create and push a tag with the number you want to start on. E.g. do
+
+```
+git tag build-number-500
+git push origin build-number-500
+```
+
+and then your next build number will be 501. The action will always delete older refs that start with `build-number-`, e.g. when it runs and finds `build-number-500` it will create a new tag, `build-number-501` and then delete `build-number-500`.
 
 ## Generating multiple independent build numbers
 
@@ -84,7 +95,7 @@ jobs:
     steps:
     - name: Generate build number
       id: buildnumber
-      uses: einaregilsson/build-number@v1 
+      uses: einaregilsson/build-number@v2 
       with:
         token: ${{ secrets.github_token }}
         prefix: client
@@ -94,19 +105,8 @@ This will generate a git tag like `client-build-number-1`.
 
 If you then do the same in another workflow and use `prefix: server` then you'll get a second build-number tag called `server-build-number-1`.
 
-## Setting the initial build number.
-
-If you're moving from another build system, you might want to start from some specific number. The `build-number` action simply uses a special tag name to store the build number, `build-number-x`, so you can just create and push a tag with the number you want to start on. E.g. do
-
-```
-git tag build-number-500
-git push origin build-number-500
-```
-
-and then your next build number will be 501. The action will always delete older refs that start with `build-number-`, e.g. when it runs and finds `build-number-500` it will create a new tag, `build-number-501` and then delete `build-number-500`.
-
 ## Branches and build numbers
 
-The build number generator is global, there's no concept of special build numbers for special branches, it's probably something you would just use on builds from your master branch. It's just one number that gets increased every time the action is run.
+The build number generator is global, there's no concept of special build numbers for special branches unless handled manually with the `prefix` property. It's probably something you would just use on builds from your master branch. It's just one number that gets increased every time the action is run.
 
 So, that's it. Hope you can use it. You can read more about how it works in this blog post: http://einaregilsson.com/a-github-action-for-generating-sequential-build-numbers/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # build-number
 GitHub action for generating sequential build numbers for GitHub actions. The build number is stored in your GitHub repository as a ref, it doesn't add any extra commits to your repository. Use in your workflow like so:
 
-```
+```yaml
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,9 +15,9 @@ jobs:
       # Or, if you're on Windows: echo "Build number is ${env:BUILD_NUMBER}"
 ```
 
-After that runs the subsequent steps in your job will have the environment variable ```BUILD_NUMBER``` available. If you prefer to be more explicit you can use the output of the step, like so:
+After that runs the subsequent steps in your job will have the environment variable `BUILD_NUMBER` available. If you prefer to be more explicit you can use the output of the step, like so:
 
-```
+```yaml
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,9 +38,9 @@ The `GITHUB_TOKEN` environment variable is defined by GitHub already for you. Se
 
 ## Getting the build number in other jobs
 
-For other steps in the same job you can use the methods above, to actually get the build number in other jobs you need some extra actions, since jobs are run in a completely clean environment. You need to use the ```actions/upload-artifact@v1``` action to save the build number as a workflow artifact, then download it at the start of the next job with ```actions/download-artifact@v1``` and then run the build number job to make it into an environment variable there again.
+For other steps in the same job you can use the methods above, to actually get the build number in other jobs you need some extra actions, since jobs are run in a completely clean environment. You need to use the `actions/upload-artifact@v1` action to save the build number as a workflow artifact, then download it at the start of the next job with `actions/download-artifact@v1` and then run the build number job to make it into an environment variable there again.
 
-```
+```yaml
 jobs:
   job1:
     runs-on: ubuntu-latest
@@ -72,21 +72,41 @@ jobs:
     # the ${{ steps.buildnumber.outputs.build_number }} output.
 ```
 
+## Generating multiple independent build numbers
+
+Sometimes you may have more than one project to build in one repository. For example you may have a client and a server in the same github repository that you would like to generate independent build numbers for. Another example is you have two Dockerfiles in one repo and you'd like to version each of the built images with their own numbers.  
+To do this, use the `prefix` key, like so:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Generate build number
+      id: buildnumber
+      uses: einaregilsson/build-number@v1 
+      with:
+        token: ${{ secrets.github_token }}
+        prefix: client
+```
+
+This will generate a git tag like `client-build-number-1`.
+
+If you then do the same in another workflow and use `prefix: server` then you'll get a second build-number tag called `server-build-number-1`.
 
 ## Setting the initial build number.
 
-If you're moving from another build system, you might want to start from some specific number. The ```build-number``` action simply uses a special tag name to store the build number, ```build-number-x```, so you can just create and push a tag with the number you want to start on. E.g. do
+If you're moving from another build system, you might want to start from some specific number. The `build-number` action simply uses a special tag name to store the build number, `build-number-x`, so you can just create and push a tag with the number you want to start on. E.g. do
 
 ```
 git tag build-number-500
 git push origin build-number-500
 ```
 
-and then your next build number will be 501. The action will always delete older refs that start with ```build-number-```, e.g. when it runs and finds ```build-number-500``` it will create a new tag, ```build-number-501``` and then delete ```build-number-500```.
+and then your next build number will be 501. The action will always delete older refs that start with `build-number-`, e.g. when it runs and finds `build-number-500` it will create a new tag, `build-number-501` and then delete `build-number-500`.
 
 ## Branches and build numbers
 
 The build number generator is global, there's no concept of special build numbers for special branches, it's probably something you would just use on builds from your master branch. It's just one number that gets increased every time the action is run.
 
 So, that's it. Hope you can use it. You can read more about how it works in this blog post: http://einaregilsson.com/a-github-action-for-generating-sequential-build-numbers/
-

--- a/action.yml
+++ b/action.yml
@@ -8,11 +8,14 @@ inputs:
   token:
     description: 'GitHub Token to create and delete refs (GITHUB_TOKEN)'
     required: false # Not required when getting the stored build number for later jobs, only in the first jobs when it's generated
-    
+  prefix:
+    description: 'Prefix for the build-number-<num> tag to make it unique if tracking multiple build numbers'
+    required: false
+
 outputs:
   build_number:
     description: 'Generated build number'
-  
+
 branding:
-  icon: 'hash'  
+  icon: 'hash'
   color: 'green'


### PR DESCRIPTION
Hey, thanks for such a useful project!

I've been using it for a few weeks to version my Docker images and it has helped me greatly. I ran into a use case that this repo doesn't quite handle yet and I wanted to contribute.

## Problem
In one of my git repositories I have 2 separate Dockerfiles with one GitHub Actions workflow file each. After my first build I realized that of course there was only 1 `build-number-#` tag generated and that both workflows were incrementing the same build number. 

## Proposal
I realized I needed different build-number tags for each workflow. My proposal is to add a `prefix` parameter that prepends the desired string onto the `build-number-#` tag. For example if ones repository is a website with a client and a server in the same repo and one wanted unique build numbers for each then this could accomplished as so:

```yaml
name: build client
...
jobs:
  docker:
    ...
    steps:
      - uses: actions/checkout@v1
      - name: Generate build number
        uses: einaregilsson/build-number@v1
        with:
          token: ${{secrets.github_token}}
          prefix: client
```

```yaml
name: build server
...
jobs:
  docker:
    ...
    steps:
      - uses: actions/checkout@v1
      - name: Generate build number
        uses: einaregilsson/build-number@v1
        with:
          token: ${{secrets.github_token}}
          prefix: server
```

These two workflows would generate 2 tags: `client-build-number-1` and `server-build-number-1`.

This solution does not break existing functionality. It is only an optional parameter that allows for multiple build numbers to track multiple unique artifacts. I have tested these changes and am currently using my fork to address my use case.

Please feel free to ask questions, make suggestions, or decline this PR. I will continue to use my fork until you merge or decline.