### PR TITLE
Support custom output environment variable name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   prefix:
     description: 'Prefix for the build-number-<num> tag to make it unique if tracking multiple build numbers'
     required: false
+  output_name:
+    description: 'Name of the output environment variable'
+    required: false
+    default: 'BUILD_NUMBER'
 
 outputs:
   build_number:

--- a/main.js
+++ b/main.js
@@ -64,13 +64,14 @@ function main() {
 
     const path = 'BUILD_NUMBER/BUILD_NUMBER';
     const prefix = env.INPUT_PREFIX ? `${env.INPUT_PREFIX}-` : '';
+    const output_name = env.INPUT_OUTPUT_NAME ? `${env.INPUT_OUTPUT_NAME}` : 'BUILD_NUMBER'
 
     //See if we've already generated the build number and are in later steps...
     if (fs.existsSync(path)) {
         let buildNumber = fs.readFileSync(path);
         console.log(`Build number already generated in earlier jobs, using build number ${buildNumber}...`);
         //Setting the output and a environment variable to new build number...
-        console.log(`::set-env name=BUILD_NUMBER::${buildNumber}`);
+        console.log(`::set-env name=${output_name}::${buildNumber}`);
         console.log(`::set-output name=build_number::${buildNumber}`);
         return;
     }
@@ -129,7 +130,7 @@ function main() {
             console.log(`Successfully updated build number to ${nextBuildNumber}`);
             
             //Setting the output and a environment variable to new build number...
-            console.log(`::set-env name=BUILD_NUMBER::${nextBuildNumber}`);
+            console.log(`::set-env name=${output_name}::${nextBuildNumber}`);
             console.log(`::set-output name=build_number::${nextBuildNumber}`);
             //Save to file so it can be used for next jobs...
             fs.writeFileSync('BUILD_NUMBER', nextBuildNumber.toString());


### PR DESCRIPTION
I'm working on porting over an existing build system from Jenkins, and we have a lot of code that expects the sequential number to be provided in a specific environment variable named `RELEASE_VERSION`.  While in theory I could add an additional explicit step in my workflow to set the RELEASE_VERSION from the existing BUILD_NUMBER, I'd rather be able to specify the output environment variable name directly in my use of this action.  This PR should hopefully support that while leaving the behavior unchanged if the environment variable name isn't specified.  

This is my first attempt at modifying an action, so I have no idea if I've missed something critical.  