### PR TITLE
Update Deprecated

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Build Number Generator'
 description: 'Generate sequential build numbers for workflow runs'
 author: 'Einar Egilsson'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'main.js'
 inputs:
   token:

--- a/main.js
+++ b/main.js
@@ -70,7 +70,7 @@ function main() {
         let buildNumber = fs.readFileSync(path);
         console.log(`Build number already generated in earlier jobs, using build number ${buildNumber}...`);
         //Setting the output and a environment variable to new build number...
-        fs.writeFileSync(process.env.GITHUB_ENV, `BUILD_NUMBER=${buildNumber}`);
+        fs.writeFileSync(process.env.GITHUB_OUTPUT, `BUILD_NUMBER=${buildNumber}`);
         console.log(`::set-output name=build_number::${buildNumber}`);
         return;
     }
@@ -130,7 +130,7 @@ function main() {
             
             //Setting the output and a environment variable to new build number...
             //fs.writeFileSync('$GITHUB_ENV', `BUILD_NUMBER=${nextBuildNumber}`);
-            fs.writeFileSync(process.env.GITHUB_ENV, `BUILD_NUMBER=${nextBuildNumber}`);
+            fs.writeFileSync(process.env.GITHUB_OUTPUT, `BUILD_NUMBER=${nextBuildNumber}`);
  
             console.log(`::set-output name=build_number::${nextBuildNumber}`);
             //Save to file so it can be used for next jobs...


### PR DESCRIPTION
This _should_ address the two Github Actions deprecations that affect this action.

- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Note: I have not tested this, since I don't know where to start. 😀 I simply want to help contribute.